### PR TITLE
Remove chrome references from RunEdgePlugin

### DIFF
--- a/packages/run-edge-extension/steps/RunEdgePlugin/index.ts
+++ b/packages/run-edge-extension/steps/RunEdgePlugin/index.ts
@@ -41,7 +41,7 @@ export default class EdgeExtensionLauncherPlugin {
     if (!fs.existsSync(msEdge) || '') {
       console.error(
         `${bgCyan(white(bold(` edge-browser `)))} ${red(`✖︎✖︎✖︎`)} ` +
-          `Chrome browser ${typeof chrome === 'undefined' ? 'is not installed.' : `is not found at ${msEdge}`}. ` +
+          `Edge browser ${typeof msEdge === 'undefined' ? 'is not installed.' : `is not found at ${msEdge}`}. ` +
           // `Either install Edge or set the EDGE environment variable to the path of the Edge executable.`
           `Either install Edge or choose a different browser via ${blue('--browser')}.`
       )


### PR DESCRIPTION
`chrome` is never defined in `RunEdgePlugin/index.ts`, it was likely just copied over from `RunChromePlugin`.

This updates the messaging, and as far as I can tell changes the `RunEdgePlugin` logic to match the `RunChromePlugin` logic.

On this branch:
```
yarn compile
yarn test

16 successful, 16 total
```