### PR TITLE
automatically update public/ assets on change

### DIFF
--- a/programs/develop/webpack/plugins/SpecialFoldersPlugin/CopyPublicFolder.ts
+++ b/programs/develop/webpack/plugins/SpecialFoldersPlugin/CopyPublicFolder.ts
@@ -71,6 +71,11 @@ export default class CopyStaticFolder {
         const target = path.join(output, path.relative(projectPath, filePath))
         this.copyFile(filePath, target)
       })
+      
+      watcher.on('change', (filePath: string) => {
+        const target = path.join(output, path.relative(projectPath, filePath))
+        this.copyFile(filePath, target)
+      })
 
       watcher.on('unlink', (filePath: string) => {
         const target = path.join(output, path.relative(projectPath, filePath))


### PR DESCRIPTION
Addresses https://github.com/cezaraugusto/extension.js/issues/62

This PR updates the behavior of the `public/` folder to be watched for changes and copy files over while the extension is running. 

### Testing

Manually tested on Firefox & Chrome with CSS & JS assets in an extension popup/action. Saw that the popup updated immediately when the files were changed without requiring a full restart.

Also ran `yarn test` and saw everything still passed.

### Other

Updated documentation here https://github.com/cezaraugusto/extension.js.org/pull/2